### PR TITLE
add adobe mc on links after the storeproduct init prices logic finishes

### DIFF
--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -3,7 +3,7 @@ import { sampleRUM } from './lib-franklin.js';
 
 import { sendAnalyticsProducts } from './adobeDataLayer.js';
 import {
-  addScript, isZuoraForNetherlandsLangMode, productsList, showLoaderSpinner, showPrices,
+  addScript, adobeMcAppendVisitorId, isZuoraForNetherlandsLangMode, productsList, showLoaderSpinner, showPrices,
 } from './utils.js';
 import ZuoraNLClass from './zuora.js';
 
@@ -27,6 +27,7 @@ async function initZuoraProductPriceLogic() {
 
           const zuoraResult = await ZuoraNLClass.loadProduct(item);
           showPrices(zuoraResult);
+          adobeMcAppendVisitorId('main');
           showLoaderSpinner(true, onSelectorClass);
           sendAnalyticsProducts(zuoraResult, 'nl');
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -719,6 +719,7 @@ function initSelectors() {
           try {
             const fp = this;
             showPrices(fp);
+            adobeMcAppendVisitorId('main');
             showLoaderSpinner(true, onSelectorClass);
           } catch (ex) { /* empty */ }
         },


### PR DESCRIPTION
Test URLs:
- Before: https://main--helix-poc--enake.hlx.page/drafts/test-page/
- After: https://hotfix-adobe-mc-buy-links--helix-poc--enake.hlx.page/drafts/test-page/
